### PR TITLE
Allow empty startTime and endTime attributes through validation

### DIFF
--- a/server/models/problem-set.js
+++ b/server/models/problem-set.js
@@ -7,7 +7,7 @@ module.exports = function(Problemset) {
   };
 
   const validateBiggerDate = function(err){
-    if(!biggerDate(this.startTime, this.endTime)){
+    if((this.startTime && this.endTime) && (!biggerDate(this.startTime, this.endTime))){
       err();
     }
   };


### PR DESCRIPTION
These changes allow empty attributes startTime and endTime, and still validates that when they are both present, endTime must be higher than startTime